### PR TITLE
Improve setup script configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@ The script:
 - installs dependencies with `npm ci` when a lock file is present, or `npm install` otherwise
 - deduplicates packages and checks for duplicates if `npm-duplicate-checker` is available
 - runs `npm doctor` for final diagnostics
+
+## Prerequisites
+
+The script assumes Node.js and npm are already installed. Using
+[nvm](https://github.com/nvm-sh/nvm) is recommended so the versions
+match what your project expects.
+
+
+## Customizing behavior
+
+Set the following environment variables before running the script to skip optional steps:
+
+- `SKIP_DEDUPE=true` — skip `npm dedupe`
+- `SKIP_NPM_DOCTOR=true` — skip the final `npm doctor` check


### PR DESCRIPTION
## Summary
- add environment variables to skip dedupe and `npm doctor`
- display path to Node and npm
- scrub proxy lines in `.npmrc` more selectively
- install packages with `--ignore-scripts`
- document prerequisites and new env vars in the README

## Testing
- `bash -n setup-env.sh`

------
https://chatgpt.com/codex/tasks/task_e_684051a3ca7c832f9d1c577ad4da54e9