### PR TITLE
Improve setup script registry check

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The script:
 - verifies that Node.js and npm are installed
 - removes npm-specific and global proxy settings
 - updates npm, refreshes the shell, and cleans the cache
+- checks installed packages and only queries the registry when they appear stale
 - installs dependencies with `npm ci` when a lock file is present, or `npm install` otherwise
 - deduplicates packages and checks for duplicates if `npm-duplicate-checker` is available
 - runs `npm doctor` for final diagnostics

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -51,8 +51,16 @@ npm cache verify >/dev/null
 # 6. Show .npmrc (if exists)
 [ -f ~/.npmrc ] && echo "📄 .npmrc:" && cat ~/.npmrc
 
-# 7. Audit outdated packages
-npm outdated --all || echo "✅ No outdated packages"
+# 7. Audit outdated packages only when dependencies look stale
+if [ -f package.json ]; then
+  echo "🔍 Verifying installed dependencies..."
+  if npm ls >/dev/null 2>&1; then
+    echo "✅ Dependencies satisfy package.json. Skipping registry check."
+  else
+    echo "🔄 Packages appear out of date. Checking registry..."
+    npm outdated --all || echo "✅ No outdated packages"
+  fi
+fi
 
 # 8. Reinstall project deps if package.json exists
 if [ -f package.json ]; then


### PR DESCRIPTION
## Summary
- only query npm registry if `npm ls` indicates stale dependencies
- mention conditional registry check in README

## Testing
- `bash -n setup-env.sh`
- `shellcheck setup-env.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840588fcb64832f97e9b2898eec5db3